### PR TITLE
Fix shortcut tray not visible on app relaunch (v3.1.2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.app.dailylog"
         minSdkVersion 23
         targetSdkVersion 36
-        versionCode 3101
-        versionName "3.1.1"
+        versionCode 3102
+        versionName "3.1.2"
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/app/src/androidTest/java/com/app/dailylog/ui/log/ShortcutTrayVisibilityTest.kt
+++ b/app/src/androidTest/java/com/app/dailylog/ui/log/ShortcutTrayVisibilityTest.kt
@@ -1,0 +1,87 @@
+package com.app.dailylog.ui.log
+
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.app.dailylog.MainActivity
+import com.app.dailylog.repository.Constants
+import com.app.dailylog.repository.Shortcut
+import com.app.dailylog.repository.ShortcutDatabase
+import com.app.dailylog.repository.ShortcutType
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces: shortcut created before app close is not visible in the tray on relaunch,
+ * but becomes visible after navigating to Settings and back.
+ *
+ * Root cause: ShortcutTrayAdapter.itemList had no custom setter, so the RecyclerView was
+ * never notified to redraw when Room's LiveData delivered its value asynchronously.
+ */
+@RunWith(AndroidJUnit4::class)
+class ShortcutTrayVisibilityTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Before
+    fun setUp() {
+        ShortcutDatabase.TEST_MODE = true
+
+        // Suppress the startup warning dialog (shown for first 3 launches)
+        context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            .edit().putInt("num_launches", 3).apply()
+
+        // Set a non-empty filename so MainActivity opens LogFragment instead of WelcomeFragment
+        context.getSharedPreferences("SharedPreferences", Context.MODE_PRIVATE)
+            .edit().putString(Constants.FILENAME_PREF_KEY, "content://fake/file").apply()
+
+        // Pre-populate the in-memory DB with a shortcut before the Activity is created,
+        // simulating a shortcut that was created in a previous session.
+        val dao = ShortcutDatabase.getDatabase(context).shortcutDao()
+        runBlocking { dao.add(Shortcut("TestShortcut", "test value", 0, ShortcutType.TEXT, 0)) }
+    }
+
+    @After
+    fun tearDown() {
+        context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE).edit().clear().apply()
+        context.getSharedPreferences("SharedPreferences", Context.MODE_PRIVATE).edit().clear().apply()
+        ShortcutDatabase.resetForTesting()
+    }
+
+    @Test
+    fun shortcut_isVisibleInTray_onLaunch() {
+        val shortcutsLoaded = CountDownLatch(1)
+
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            // Wait until the repository's LiveData has emitted the shortcut list.
+            // The adapter observer is registered before this one, so by the time
+            // the latch counts down the adapter has already received the data.
+            scenario.onActivity { activity ->
+                activity.repository.getAllShortcuts().observeForever { shortcuts ->
+                    if (shortcuts.isNotEmpty()) shortcutsLoaded.countDown()
+                }
+            }
+
+            assertTrue(
+                "Shortcuts LiveData did not emit within 5 seconds",
+                shortcutsLoaded.await(5, TimeUnit.SECONDS)
+            )
+
+            // Espresso syncs with the main thread before the check, allowing any
+            // pending RecyclerView layout passes (triggered by notifyDataSetChanged)
+            // to complete before asserting visibility.
+            onView(withText("TestShortcut")).check(matches(isDisplayed()))
+        }
+    }
+}

--- a/app/src/main/java/com/app/dailylog/repository/ShortcutDatabase.kt
+++ b/app/src/main/java/com/app/dailylog/repository/ShortcutDatabase.kt
@@ -38,6 +38,15 @@ abstract class ShortcutDatabase : RoomDatabase() {
             }
         }
 
+        @VisibleForTesting
+        fun resetForTesting() {
+            synchronized(this) {
+                INSTANCE?.close()
+                INSTANCE = null
+                TEST_MODE = false
+            }
+        }
+
         fun getDatabase(context: Context): ShortcutDatabase {
             val tempInstance = INSTANCE
             if (tempInstance != null) {

--- a/app/src/main/java/com/app/dailylog/ui/log/ShortcutTrayAdapter.kt
+++ b/app/src/main/java/com/app/dailylog/ui/log/ShortcutTrayAdapter.kt
@@ -17,6 +17,10 @@ class ShortcutTrayAdapter internal constructor(
     RecyclerView.Adapter<ShortcutTrayAdapter.ViewHolder>() {
 
     var itemList: List<Shortcut> = ArrayList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
 
     // inflates the cell layout from xml when needed
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {


### PR DESCRIPTION
## Summary

- Fixes a bug where shortcuts were invisible in the tray after closing and reopening the app, but became visible after navigating to Settings and back
- Adds an instrumentation test that reproduces the bug
- Bumps version to 3.1.2

## Root cause

`ShortcutTrayAdapter.itemList` was a plain property with no custom setter. On first launch, Room delivers the initial query result asynchronously via `postValue()`. The observer fires and sets `adapter.itemList` after the adapter is already attached to the RecyclerView — but with no `notifyDataSetChanged()` call, the RecyclerView never redraws.

When returning from Settings, the LiveData has a cached value and delivers it synchronously *during* the `observe()` call, before `tray.adapter = adapter` is set. So the adapter already has data when the RecyclerView receives it, and it renders correctly — which is why the workaround of going to Settings and back worked.

## Fix

Added a custom setter on `ShortcutTrayAdapter.itemList` that calls `notifyDataSetChanged()`, so the RecyclerView always redraws when data arrives regardless of delivery timing.

## Test plan

- [x] Run `./gradlew connectedAndroidTest` on a device/emulator — `ShortcutTrayVisibilityTest.shortcut_isVisibleInTray_onLaunch` should pass
- [x] Manually: create a shortcut, close the app, reopen — shortcut should be visible immediately in the tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)